### PR TITLE
Revamp landing page styling and layout

### DIFF
--- a/assets/css/custom.scss
+++ b/assets/css/custom.scss
@@ -1,39 +1,398 @@
-/* Professional typography and readable width */
-html { font-size: 16px; }
+@import url("https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&family=Source+Serif+4:wght@400;600&display=swap");
+
+:root {
+  --accent: #2563eb;
+  --accent-dark: #1d4ed8;
+  --accent-muted: #93c5fd;
+  --surface: #f8fafc;
+  --surface-strong: #0f172a;
+  --text-primary: #0b1120;
+  --text-muted: #4b5563;
+  --card-border: rgba(148, 163, 184, 0.35);
+}
+
+html {
+  font-size: 16px;
+}
+
 body {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Inter, Arial;
-  line-height: 1.6;
-  color: #1f2937;
-  background: #fff;
+  font-family: "Poppins", "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  line-height: 1.7;
+  color: var(--text-primary);
+  background: radial-gradient(circle at top right, rgba(37, 99, 235, 0.12), transparent 40%),
+    radial-gradient(circle at 20% 20%, rgba(14, 165, 233, 0.08), transparent 35%),
+    #ffffff;
+  min-height: 100vh;
 }
 
-/* Constrain content width across theme wrappers */
-article, .page__content, .page__inner-wrap, main, .archive, .sidebar, .initial-content, .page {
-  max-width: 860px;
+.page {
+  max-width: 1080px;
   margin: 0 auto;
-  padding: 0 1.2rem;
+  padding: 0 2.5rem 4rem;
 }
 
-/* Headings (not huge) */
-h1 { font-size: 2rem;   line-height: 1.2; margin: 1.2rem 0 .8rem; font-weight: 700; }
-h2 { font-size: 1.5rem; line-height: 1.3; margin: 1.0rem 0 .6rem; font-weight: 650; }
-h3 { font-size: 1.25rem; line-height: 1.35; margin: .8rem 0 .5rem; font-weight: 600; }
+@media (max-width: 768px) {
+  .page {
+    padding: 0 1.6rem 3rem;
+  }
+}
+
+/* Masthead alignment */
+.masthead {
+  background: transparent;
+  box-shadow: none;
+  padding: 1.8rem 0 1.2rem;
+}
+
+.masthead__inner-wrap {
+  display: flex;
+  align-items: center;
+  gap: 2rem;
+  padding: 0;
+}
+
+.site-title {
+  font-family: "Source Serif 4", "Times New Roman", serif;
+  font-weight: 600;
+  font-size: 1.75rem;
+  margin: 0;
+  color: var(--text-primary);
+}
+
+nav#site-nav {
+  margin-left: auto;
+}
+
+nav#site-nav ul,
+.masthead__menu ul,
+.site-nav ul {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+nav#site-nav a,
+.masthead__menu a,
+.site-nav a {
+  font-weight: 500;
+  color: var(--text-primary);
+  letter-spacing: 0.01em;
+  transition: color 0.2s ease;
+}
+
+nav#site-nav a:hover,
+.masthead__menu a:hover,
+.site-nav a:hover {
+  color: var(--accent);
+}
+
+/* Typography */
+h1,
+h2,
+h3,
+h4 {
+  font-family: "Source Serif 4", "Times New Roman", serif;
+  font-weight: 600;
+  color: var(--surface-strong);
+  margin: 0 0 0.75rem;
+}
+
+h1 {
+  font-size: clamp(2.4rem, 4vw, 3rem);
+  line-height: 1.15;
+}
+
+h2 {
+  font-size: clamp(1.8rem, 3vw, 2.4rem);
+  line-height: 1.2;
+}
+
+h3 {
+  font-size: clamp(1.35rem, 2.2vw, 1.7rem);
+  line-height: 1.3;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+a:hover {
+  color: var(--accent-dark);
+  text-decoration: none;
+}
+
+p {
+  margin: 0 0 1.2rem;
+  color: var(--text-muted);
+}
+
+/* Hero */
+.landing-hero {
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.9), rgba(37, 99, 235, 0.65));
+  color: #f8fafc;
+  border-radius: 28px;
+  padding: clamp(2.5rem, 6vw, 4rem);
+  margin: 0 0 3rem;
+  position: relative;
+  overflow: hidden;
+  min-height: 70vh;
+  display: grid;
+  align-content: center;
+  gap: 1.4rem;
+}
+
+.landing-hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 20% 20%, rgba(148, 163, 184, 0.35), transparent 55%),
+    radial-gradient(circle at 80% 15%, rgba(191, 219, 254, 0.45), transparent 50%);
+  pointer-events: none;
+}
+
+.landing-hero__content {
+  position: relative;
+  z-index: 1;
+  max-width: 640px;
+}
+
+.landing-hero__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.2);
+  color: #e2e8f0;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.landing-hero p {
+  color: #e2e8f0;
+  font-size: 1.05rem;
+}
+
+.landing-hero__cta {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  padding: 0.75rem 1.75rem;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.btn--primary {
+  background: #ffffff;
+  color: var(--surface-strong);
+  box-shadow: 0 12px 25px rgba(15, 23, 42, 0.25);
+}
+
+.btn--primary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 30px rgba(15, 23, 42, 0.3);
+}
+
+.btn--ghost {
+  background: rgba(255, 255, 255, 0.12);
+  color: #f8fafc;
+  border: 1px solid rgba(226, 232, 240, 0.4);
+}
+
+.btn--ghost:hover {
+  background: rgba(255, 255, 255, 0.22);
+}
+
+.landing-hero__stats {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: 1rem;
+  margin: 0;
+  padding: 1.2rem 1.4rem;
+  border-radius: 18px;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  list-style: none;
+}
+
+.landing-hero__stats li {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.landing-hero__stats .label {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: rgba(226, 232, 240, 0.6);
+}
+
+.landing-hero__stats .value {
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: #f8fafc;
+}
+
+/* Highlights */
+.landing-highlights {
+  display: grid;
+  gap: 1.8rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  margin-bottom: 3.2rem;
+}
+
+.landing-card {
+  background: #ffffff;
+  border: 1px solid var(--card-border);
+  border-radius: 22px;
+  padding: 1.8rem;
+  box-shadow: 0 15px 35px rgba(15, 23, 42, 0.08);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.landing-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.12);
+}
+
+.landing-card p {
+  color: var(--text-muted);
+}
+
+.landing-card ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.45rem;
+}
+
+.landing-card li::before {
+  content: "\2713";
+  color: var(--accent);
+  font-weight: 600;
+  margin-right: 0.5rem;
+}
+
+/* Outline */
+.landing-outline {
+  margin-bottom: 3.5rem;
+}
+
+.landing-outline__grid {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.landing-outline__item {
+  background: var(--surface);
+  border-radius: 20px;
+  padding: 1.8rem;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+}
+
+.landing-outline__item h3 {
+  margin-bottom: 0.5rem;
+}
+
+.landing-outline__item ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: grid;
+  gap: 0.35rem;
+}
 
 /* Links */
-a { color: #2563eb; text-decoration: none; }
-a:hover { text-decoration: underline; }
+.landing-links {
+  text-align: center;
+}
 
-/* Code & Tables */
-code, pre { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace; font-size: .95rem; }
-table { border-collapse: collapse; width: 100%; }
-th, td { border-bottom: 1px solid #e5e7eb; padding: .5rem .6rem; text-align: left; }
-th { color: #6b7280; font-weight: 600; }
+.landing-links__grid {
+  margin-top: 1.6rem;
+  display: inline-grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
 
-/* Mermaid diagram spacing */
-.mermaid { margin: 1rem 0; }
+.landing-links__grid a {
+  border-radius: 16px;
+  padding: 1rem 1.5rem;
+  border: 1px solid var(--card-border);
+  background: #ffffff;
+  color: var(--surface-strong);
+  font-weight: 600;
+  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.08);
+}
+
+.landing-links__grid a:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+  transform: translateY(-2px);
+}
+
+/* Tables and code */
+code,
+pre {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+  font-size: 0.95rem;
+}
+
+table {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+th,
+td {
+  border-bottom: 1px solid #e5e7eb;
+  padding: 0.5rem 0.6rem;
+  text-align: left;
+}
+
+th {
+  color: #6b7280;
+  font-weight: 600;
+}
+
+.mermaid {
+  margin: 1rem 0;
+}
 
 /* Hide footer/meta/pagination */
-.page__footer, .site-footer { display: none !important; }
-.page__meta, .page__share { display: none !important; }
-.post-pagination, .pagination { display: none !important; }
-.page__date, .page__meta-date, .post__date, .time { display: none !important; }
+.page__footer,
+.site-footer {
+  display: none !important;
+}
+
+.page__meta,
+.page__share {
+  display: none !important;
+}
+
+.post-pagination,
+.pagination {
+  display: none !important;
+}
+
+.page__date,
+.page__meta-date,
+.post__date,
+.time {
+  display: none !important;
+}

--- a/index.md
+++ b/index.md
@@ -1,20 +1,102 @@
 ---
 layout: single
 permalink: /
-
+classes: landing
 ---
 
-Cybersecurity today is a race between defenders and attackers. Every piece of software and infrastructure you rely on—from operating systems to cloud workloads to third-party libraries—can become a doorway for risk if not properly managed. That’s where **Vulnerability Management (VM)** comes in.
+<section class="landing-hero">
+  <div class="landing-hero__content">
+    <span class="landing-hero__badge">Cybersecurity Portfolio</span>
+    <h1>Build resilient vulnerability management from strategy to execution</h1>
+    <p>
+      This space is my hands-on guide to what modern defenders need: practical frameworks, tooling tradeoffs,
+      and battle-tested processes that keep risk visible and actionable across cloud, on-prem, and hybrid estates.
+    </p>
+    <div class="landing-hero__cta">
+      <a class="btn btn--primary" href="/kb/">Explore the Knowledge Base</a>
+      <a class="btn btn--ghost" href="/about/">Learn About Me</a>
+    </div>
+  </div>
+  <ul class="landing-hero__stats">
+    <li>
+      <span class="label">Coverage</span>
+      <span class="value">Foundations · Scanning · Prioritization · Advanced Practices</span>
+    </li>
+    <li>
+      <span class="label">Outcomes</span>
+      <span class="value">Fewer blind spots, faster remediation cycles, measurable risk reduction</span>
+    </li>
+    <li>
+      <span class="label">Voice</span>
+      <span class="value">From DevSecOps leadership to tactical response, distilled and actionable</span>
+    </li>
+  </ul>
+</section>
 
-This knowledge base is designed to give you a clear, practical understanding of VM:  
-- **Foundations**: Learn what CVEs are, how the CIA triad guides security, and how to read CPEs, CVSS scores, and EPSS predictions.  
-- **Scanning Approaches**: Explore host-based agents, network scans, SBOM analysis, and static code checks—plus how combining them reduces blind spots.  
-- **Prioritization & Fixes**: Discover how to turn scan results into real protection by focusing on exploitability, exposure, and business impact.  
-- **Advanced Topics**: See how VM fits into cloud workloads, containers, and Kubernetes; how standards like PCI or HIPAA tie in; and how to integrate AI/ML to cut false positives.  
-- **Future Trends**: Contextual package analysis, LLM-augmented SCA, continuous threat exposure management, and more.  
+<section class="landing-highlights">
+  <article class="landing-card">
+    <h3>Strategic Foundations</h3>
+    <p>Understand the language of risk, governance, and measurement that underpins a mature VM program.</p>
+    <ul>
+      <li>CVEs, CPEs, CVSS &amp; EPSS decoded</li>
+      <li>Align remediation with the CIA triad</li>
+      <li>Metrics that boards and engineers trust</li>
+    </ul>
+  </article>
+  <article class="landing-card">
+    <h3>Operational Playbooks</h3>
+    <p>Balance host agents, network scans, SBOM insights, and SAST to shrink the unknowns in your estate.</p>
+    <ul>
+      <li>Comparative tooling guidance</li>
+      <li>Workflow blueprints from intake to fix</li>
+      <li>Exposure-led prioritization models</li>
+    </ul>
+  </article>
+  <article class="landing-card">
+    <h3>Forward Momentum</h3>
+    <p>Bring automation, AI augmentation, and continuous threat exposure management into daily practice.</p>
+    <ul>
+      <li>Cloud-native and container hardening</li>
+      <li>Compliance-ready controls mapping</li>
+      <li>Future-looking research and experiments</li>
+    </ul>
+  </article>
+</section>
 
-Think of this as your **guided path** from basics to advanced practice. Whether you’re a student, a security engineer, or a leader building strategy, you’ll find material that explains **what matters, why it matters, and how to act**.
+<section class="landing-outline">
+  <h2>What you'll find inside</h2>
+  <div class="landing-outline__grid">
+    <article class="landing-outline__item">
+      <h3>Learn the essentials</h3>
+      <ul>
+        <li>Why vulnerability management is more than patching</li>
+        <li>How to interpret scanning outputs with business context</li>
+        <li>When to lean on automation versus expert review</li>
+      </ul>
+    </article>
+    <article class="landing-outline__item">
+      <h3>Scale with confidence</h3>
+      <ul>
+        <li>Design decision trees for tooling and coverage</li>
+        <li>Embed VM into DevSecOps workflows and roadmaps</li>
+        <li>Measure effectiveness with leading and lagging indicators</li>
+      </ul>
+    </article>
+    <article class="landing-outline__item">
+      <h3>Stay ahead of threats</h3>
+      <ul>
+        <li>Pair CTEM programs with threat intelligence</li>
+        <li>Experiment with LLM-augmented analysis responsibly</li>
+        <li>Map compliance requirements into engineering reality</li>
+      </ul>
+    </article>
+  </div>
+</section>
 
-
-- **[Knowledge Base →](/kb/)**
-- **[About Me](/about/)**
+<section class="landing-links">
+  <h2>Dive deeper where it matters</h2>
+  <div class="landing-links__grid">
+    <a href="/kb/">Knowledge Base →</a>
+    <a href="/about/">About Me →</a>
+  </div>
+</section>


### PR DESCRIPTION
## Summary
- Replaced the home page copy with a hero, highlights, and outline sections that fill the viewport and emphasize key portfolio content
- Applied new professional typography, navigation alignment, and background styling for a cohesive presentation
- Added reusable button, card, and link styles to keep CTAs and supporting content visually consistent

## Testing
- bundle exec jekyll build *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_68da55bd00dc8322a144183c2e623a82